### PR TITLE
Change MonsterId from String to UUID

### DIFF
--- a/app/src/main/java/com/arcathoria/monster/MonsterQueryFacade.java
+++ b/app/src/main/java/com/arcathoria/monster/MonsterQueryFacade.java
@@ -3,6 +3,8 @@ package com.arcathoria.monster;
 import com.arcathoria.monster.dto.MonsterDTO;
 import com.arcathoria.monster.vo.MonsterId;
 
+import java.util.UUID;
+
 public class MonsterQueryFacade {
 
     private final GetMonsterByIdUseCase getMonsterByIdUseCase;
@@ -11,7 +13,7 @@ public class MonsterQueryFacade {
         this.getMonsterByIdUseCase = getMonsterByIdUseCase;
     }
 
-    MonsterDTO getMonsterById(final String id) {
+    MonsterDTO getMonsterById(final UUID id) {
         return MonsterMapper.toMonsterDTO(getMonsterByIdUseCase.execute(new MonsterId(id)));
     }
 }

--- a/app/src/main/java/com/arcathoria/monster/dto/MonsterDTO.java
+++ b/app/src/main/java/com/arcathoria/monster/dto/MonsterDTO.java
@@ -1,4 +1,6 @@
 package com.arcathoria.monster.dto;
 
-public record MonsterDTO(String id, String name, Double currentHealth, Double maxHealth) {
+import java.util.UUID;
+
+public record MonsterDTO(UUID id, String name, Double currentHealth, Double maxHealth) {
 }

--- a/app/src/main/java/com/arcathoria/monster/exception/MonsterNotFoundException.java
+++ b/app/src/main/java/com/arcathoria/monster/exception/MonsterNotFoundException.java
@@ -2,16 +2,18 @@ package com.arcathoria.monster.exception;
 
 import com.arcathoria.ApiException;
 
+import java.util.UUID;
+
 public class MonsterNotFoundException extends ApiException {
 
-    private final String monsterId;
+    private final UUID monsterId;
 
-    public MonsterNotFoundException(final String monsterId) {
+    public MonsterNotFoundException(final UUID monsterId) {
         super("Monster with id " + monsterId + " not found!", "ERR_MONSTER_NOT_FOUND-404");
         this.monsterId = monsterId;
     }
 
-    public String getMonsterId() {
+    public UUID getMonsterId() {
         return monsterId;
     }
 }

--- a/app/src/test/java/com/arcathoria/monster/GetMonsterByIdUseCaseTest.java
+++ b/app/src/test/java/com/arcathoria/monster/GetMonsterByIdUseCaseTest.java
@@ -41,7 +41,7 @@ class GetMonsterByIdUseCaseTest {
     void should_return_MonsterNotFoundException_when_id_is_not_correct() {
         when(monsterQueryRepository.getById(any(MonsterId.class))).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> getMonsterByIdUseCase.execute(new MonsterId("example_bad_id_test")))
+        assertThatThrownBy(() -> getMonsterByIdUseCase.execute(new MonsterId(null)))
                 .isInstanceOf(MonsterNotFoundException.class)
                 .message().contains("Monster with id");
     }

--- a/domain/src/main/java/com/arcathoria/monster/vo/MonsterId.java
+++ b/domain/src/main/java/com/arcathoria/monster/vo/MonsterId.java
@@ -1,4 +1,6 @@
 package com.arcathoria.monster.vo;
 
-public record MonsterId(String value) {
+import java.util.UUID;
+
+public record MonsterId(UUID value) {
 }

--- a/infrastructure/src/main/java/com/arcathoria/monster/FileMonsterQueryRepositoryAdapter.java
+++ b/infrastructure/src/main/java/com/arcathoria/monster/FileMonsterQueryRepositoryAdapter.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 class FileMonsterQueryRepositoryAdapter implements MonsterQueryRepository {
 
     private static final Logger log = LogManager.getLogger(FileMonsterQueryRepositoryAdapter.class);
-    private final Map<String, FileMonsterDTO> monsterMap;
+    private final Map<UUID, FileMonsterDTO> monsterMap;
 
     FileMonsterQueryRepositoryAdapter(final ObjectMapper objectMapper) {
         try {

--- a/infrastructure/src/main/java/com/arcathoria/monster/MonsterController.java
+++ b/infrastructure/src/main/java/com/arcathoria/monster/MonsterController.java
@@ -4,6 +4,8 @@ import com.arcathoria.monster.dto.MonsterDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/monsters")
 class MonsterController {
@@ -16,7 +18,8 @@ class MonsterController {
 
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    MonsterDTO getMonsterById(final @PathVariable String id) {
+    MonsterDTO getMonsterById(final @PathVariable UUID id) {
         return monsterQueryFacade.getMonsterById(id);
     }
 }
+

--- a/infrastructure/src/main/java/com/arcathoria/monster/dto/FileMonsterDTO.java
+++ b/infrastructure/src/main/java/com/arcathoria/monster/dto/FileMonsterDTO.java
@@ -1,4 +1,6 @@
 package com.arcathoria.monster.dto;
 
-public record FileMonsterDTO(String monsterId, String monsterName, double currentHealth, double maxHealth) {
+import java.util.UUID;
+
+public record FileMonsterDTO(UUID monsterId, String monsterName, double currentHealth, double maxHealth) {
 }

--- a/infrastructure/src/main/resources/monsters.json
+++ b/infrastructure/src/main/resources/monsters.json
@@ -1,6 +1,6 @@
 [
   {
-    "monsterId": "wolf",
+    "monsterId": "bf4397d8-b4dc-361e-9b6d-191a352e9134",
     "monsterName": "Wilk",
     "health": {
       "current": 100,

--- a/infrastructure/src/test/java/com/arcathoria/monster/FileMonsterQueryRepositoryAdapterTest.java
+++ b/infrastructure/src/test/java/com/arcathoria/monster/FileMonsterQueryRepositoryAdapterTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,7 +19,8 @@ class FileMonsterQueryRepositoryAdapterTest extends IntegrationTestContainersCon
 
     @Test
     void should_return_monster_by_id_if_present() {
-        MonsterId monsterId = new MonsterId("wolf");
+        UUID wolfUuid = UUID.fromString("bf4397d8-b4dc-361e-9b6d-191a352e9134");
+        MonsterId monsterId = new MonsterId(wolfUuid);
 
         Optional<Monster> result = adapter.getById(monsterId);
 

--- a/infrastructure/src/test/java/com/arcathoria/monster/MonsterControllerE2ETest.java
+++ b/infrastructure/src/test/java/com/arcathoria/monster/MonsterControllerE2ETest.java
@@ -33,7 +33,7 @@ class MonsterControllerE2ETest extends IntegrationTestContainersConfig {
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
         ResponseEntity<MonsterDTO> response = restTemplate.exchange(
-                baseUrl + "/wolf",
+                baseUrl + "/bf4397d8-b4dc-361e-9b6d-191a352e9134",
                 HttpMethod.GET,
                 requestEntity,
                 MonsterDTO.class
@@ -41,7 +41,7 @@ class MonsterControllerE2ETest extends IntegrationTestContainersConfig {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().id()).isEqualTo("wolf");
+        assertThat(response.getBody().name()).isEqualTo("Wilk");
     }
 
     @Test
@@ -51,7 +51,7 @@ class MonsterControllerE2ETest extends IntegrationTestContainersConfig {
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
         ResponseEntity<ApiErrorResponse> response = restTemplate.exchange(
-                baseUrl + "/badmonsterid",
+                baseUrl + "/00000000-0000-0000-0000-000000000000",
                 HttpMethod.GET,
                 requestEntity,
                 ApiErrorResponse.class

--- a/shared-test-helpers/src/main/java/com/arcathoria/monster/MonsterSnapshotMother.java
+++ b/shared-test-helpers/src/main/java/com/arcathoria/monster/MonsterSnapshotMother.java
@@ -5,7 +5,7 @@ import com.arcathoria.monster.vo.MonsterId;
 import com.arcathoria.monster.vo.MonsterName;
 
 public final class MonsterSnapshotMother {
-    public static final MonsterId DEFAULT_MONSTER_ID = new MonsterId("wolf");
+    public static final MonsterId DEFAULT_MONSTER_ID = new MonsterId(null);
     public static final MonsterName DEFAULT_MONSTER_NAME = new MonsterName("Wolf");
     public static final Health DEFAULT_HEALTH = new Health(100.0, 100.0);
 
@@ -20,17 +20,17 @@ public final class MonsterSnapshotMother {
         return new MonsterSnapshotMother();
     }
 
-    MonsterSnapshotMother withMonsterId(MonsterId monsterId) {
+    MonsterSnapshotMother withMonsterId(final MonsterId monsterId) {
         this.monsterId = monsterId;
         return this;
     }
 
-    MonsterSnapshotMother withMonsterName(MonsterName monsterName) {
+    MonsterSnapshotMother withMonsterName(final MonsterName monsterName) {
         this.monsterName = monsterName;
         return this;
     }
 
-    MonsterSnapshotMother withHealth(Health health) {
+    MonsterSnapshotMother withHealth(final Health health) {
         this.health = health;
         return this;
     }


### PR DESCRIPTION
Refactor `MonsterId` to use `UUID` instead of `String`. Updated implementations and tests to support the new `UUID` usage.